### PR TITLE
Modify CsvDataAccessProvider to buffer writes

### DIFF
--- a/FireMothConsole/Initializer.cs
+++ b/FireMothConsole/Initializer.cs
@@ -121,13 +121,15 @@ namespace RiotClub.FireMoth.Console
                 + DateTime.Now.ToString(DefaultFileDateTimeFormat, CultureInfo.InvariantCulture)
                 + '.' + DefaultFileExtension;
 
+            // This is closed when the encapsulating CsvDataAccessProvider is disposed.
+            StreamWriter dataOutputWriter = new StreamWriter(this.dataOutputFile, false);
+
             using (SHA256 hasher = SHA256.Create())
-            using (StreamWriter dataOutputWriter = new StreamWriter(this.dataOutputFile, false))
+            using (CsvDataAccessProvider dataAccessProvider = new CsvDataAccessProvider(
+                dataOutputWriter))
             {
-                CsvDataAccessProvider dataAccessProvider =
-                    new CsvDataAccessProvider(dataOutputWriter);
-                var fileScanner =
-                    new FileScanner(dataAccessProvider, hasher, this.statusOutputWriter);
+                var fileScanner = new FileScanner(
+                    dataAccessProvider, hasher, this.statusOutputWriter);
 
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();

--- a/FireMothServices.Tests/DataAccess/CsvDataAccessProviderTests.cs
+++ b/FireMothServices.Tests/DataAccess/CsvDataAccessProviderTests.cs
@@ -170,39 +170,19 @@ namespace RiotClub.FireMoth.Services.FileScanning
             mockFileInfo.SetupGet(mock => mock.PhysicalPath).Returns(file);
             mockFileInfo.SetupGet(mock => mock.Name).Returns(testFileName);
 
-            var mockStreamWriter = new Mock<TextWriter>(MockBehavior.Strict);
-            var callSequence = new MockSequence();
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.Write(testPath));
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.Write(","));
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.Write(testFileName));
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.Write(","));
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.Write(hash));
-            mockStreamWriter
-                .InSequence(callSequence)
-                .Setup(writer => writer.WriteLine());
-
-            CsvDataAccessProvider testObject = new CsvDataAccessProvider(mockStreamWriter.Object);
+            var mockStreamWriter = new Mock<TextWriter>(MockBehavior.Default);
 
             // Act
-            testObject.AddFileRecord(mockFileInfo.Object, hash);
+            using (CsvDataAccessProvider testObject =
+                new CsvDataAccessProvider(mockStreamWriter.Object))
+            {
+                testObject.AddFileRecord(mockFileInfo.Object, hash);
+            }
 
             // Assert
             mockStreamWriter.Verify(writer => writer.Write(testPath));
-            mockStreamWriter.Verify(writer => writer.Write(","));
             mockStreamWriter.Verify(writer => writer.Write(testFileName));
-            mockStreamWriter.Verify(writer => writer.Write(","));
             mockStreamWriter.Verify(writer => writer.Write(hash));
-            mockStreamWriter.Verify(writer => writer.WriteLine());
         }
 
         /// <inheritdoc/>

--- a/FireMothServices/DataAccess/CsvDataAccessProvider.cs
+++ b/FireMothServices/DataAccess/CsvDataAccessProvider.cs
@@ -15,18 +15,26 @@ namespace RiotClub.FireMoth.Services.DataAccess
     /// <summary>
     /// Implementation of a data access provider that persists data to a stream in CSV format.
     /// </summary>
-    public class CsvDataAccessProvider : IDataAccessProvider
+    public class CsvDataAccessProvider : IDataAccessProvider, IDisposable
     {
-        private TextWriter csvWriter;
+        private CsvWriter csvWriter;
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CsvDataAccessProvider"/> class.
         /// </summary>
         /// <param name="outputWriter">The <see cref="TextWriter"/> object to which data is written.
         /// </param>
-        public CsvDataAccessProvider(TextWriter outputWriter)
+        /// <param name="leaveOpen">If <c>true</c>, the underlying <see cref="TextWriter"/> will not
+        /// be closed when the <see cref="CsvDataAccessProvider"/> is disposed.</param>
+        public CsvDataAccessProvider(TextWriter outputWriter, bool leaveOpen = false)
         {
-            this.csvWriter = outputWriter ?? throw new ArgumentNullException(nameof(outputWriter));
+            if (outputWriter == null)
+            {
+                throw new ArgumentNullException(nameof(outputWriter));
+            }
+
+            this.csvWriter = new CsvWriter(outputWriter, CultureInfo.InvariantCulture, leaveOpen);
         }
 
         /// <inheritdoc/>
@@ -58,18 +66,35 @@ namespace RiotClub.FireMoth.Services.DataAccess
                 throw new ArgumentException("Not a valid base 64 string.", nameof(base64Hash));
             }
 
-            FileFingerprint fingerprint = new FileFingerprint();
-            fingerprint.FilePath = Path.GetDirectoryName(fileInfo.PhysicalPath);
-            fingerprint.FileName = fileInfo.Name;
-            fingerprint.Base64Hash = base64Hash;
+            FileFingerprint fingerprint = BuildFileFingerprint(fileInfo, base64Hash);
+            this.csvWriter.WriteRecord(fingerprint);
+            this.csvWriter.NextRecord();
+        }
 
-            using (var csvHelper = new CsvWriter(this.csvWriter, CultureInfo.InvariantCulture, true))
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and, optionally, managed resources.
+        /// </summary>
+        /// <param name="disposing">If true, managed resources are freed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.disposed)
             {
-                csvHelper.WriteRecord(fingerprint);
-                csvHelper.Flush();
+                return;
             }
 
-            this.csvWriter.WriteLine();
+            if (disposing)
+            {
+                this.csvWriter.Dispose();
+            }
+
+            this.disposed = true;
         }
 
         /// <summary>
@@ -81,6 +106,27 @@ namespace RiotClub.FireMoth.Services.DataAccess
         {
             Span<byte> buffer = new Span<byte>(new byte[base64.Length]);
             return Convert.TryFromBase64String(base64, buffer, out _);
+        }
+
+
+        /// <summary>
+        /// Builds a <see cref="FileFingerprint"/> object from the provided <see cref="IFileInfo"/>
+        /// and base 64 hash string.
+        /// </summary>
+        /// <param name="fileInfo">The <see cref="IFileInfo"/> implementation containing the file
+        /// information to use for the returned <see cref="FileFingerprint"/>.</param>
+        /// <param name="base64Hash">A <c>string</c> containing the base 64 hash string to use in
+        /// the returned <see cref="FileFingerprint"/>.</param>
+        /// <returns>A new <see cref="FileFingerprint"/> object containing the provided
+        /// information.</returns>
+        private static FileFingerprint BuildFileFingerprint(IFileInfo fileInfo, string base64Hash)
+        {
+            return new FileFingerprint
+            {
+                FilePath = Path.GetDirectoryName(fileInfo.PhysicalPath),
+                FileName = fileInfo.Name,
+                Base64Hash = base64Hash,
+            };
         }
     }
 }

--- a/FireMothServices/FireMothServices.xml
+++ b/FireMothServices/FireMothServices.xml
@@ -9,15 +9,26 @@
             Implementation of a data access provider that persists data to a stream in CSV format.
             </summary>
         </member>
-        <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.#ctor(System.IO.TextWriter)">
+        <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.#ctor(System.IO.TextWriter,System.Boolean)">
             <summary>
             Initializes a new instance of the <see cref="T:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider"/> class.
             </summary>
             <param name="outputWriter">The <see cref="T:System.IO.TextWriter"/> object to which data is written.
             </param>
+            <param name="leaveOpen">If <c>true</c>, the underlying <see cref="T:System.IO.TextWriter"/> will not
+            be closed when the <see cref="T:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider"/> is disposed.</param>
         </member>
         <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.AddFileRecord(Microsoft.Extensions.FileProviders.IFileInfo,System.String)">
             <inheritdoc/>
+        </member>
+        <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.Dispose">
+            <inheritdoc/>
+        </member>
+        <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.Dispose(System.Boolean)">
+            <summary>
+            Releases unmanaged and, optionally, managed resources.
+            </summary>
+            <param name="disposing">If true, managed resources are freed.</param>
         </member>
         <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.IsBase64String(System.String)">
             <summary>
@@ -25,6 +36,18 @@
             </summary>
             <param name="base64">A <see cref="T:System.String"/> to check for base 64 validity.</param>
             <returns><c>true</c> if the provided string is a valid base 64 string.</returns>
+        </member>
+        <member name="M:RiotClub.FireMoth.Services.DataAccess.CsvDataAccessProvider.BuildFileFingerprint(Microsoft.Extensions.FileProviders.IFileInfo,System.String)">
+            <summary>
+            Builds a <see cref="T:FireMothServices.DataAccess.FileFingerprint"/> object from the provided <see cref="T:Microsoft.Extensions.FileProviders.IFileInfo"/>
+            and base 64 hash string.
+            </summary>
+            <param name="fileInfo">The <see cref="T:Microsoft.Extensions.FileProviders.IFileInfo"/> implementation containing the file
+            information to use for the returned <see cref="T:FireMothServices.DataAccess.FileFingerprint"/>.</param>
+            <param name="base64Hash">A <c>string</c> containing the base 64 hash string to use in
+            the returned <see cref="T:FireMothServices.DataAccess.FileFingerprint"/>.</param>
+            <returns>A new <see cref="T:FireMothServices.DataAccess.FileFingerprint"/> object containing the provided
+            information.</returns>
         </member>
         <member name="T:RiotClub.FireMoth.Services.DataAccess.IDataAccessProvider">
             <summary>


### PR DESCRIPTION
CsvDataAccessProvider no longer explicitly writes each row to the
underlying stream, instead allowing the encapsulated CsvWriter to
buffer writes.

Modified dependent Initializer class to accommodate refactor.

Modified unit tests to accommodate refactor.