### PR TITLE
Fix bug with quoted command line path arguments

### DIFF
--- a/FireMothConsole.Tests/InitializerTests.cs
+++ b/FireMothConsole.Tests/InitializerTests.cs
@@ -28,7 +28,10 @@ namespace RiotClub.FireMoth.Console
      *
      * x Init without recursive scan flag argument.
      *      x Initialize_RecursiveFlagArgumentDoesNotExist_SetsRecursiveScanOptionToFalse
-
+     *
+     * x Init with directory argument containing trailing double quote removes double quote.
+     *      x Initialize_QuotedDirectoryArgumentEndsWithBackslash_SetsDirectoryOptionWithoutTrailingDoubleQuote
+     *
      * x Init with invalid directory argument displays error (don't check for directory existence).
      *      x Initialize_InvalidDirectoryArgument_ReturnsFalse
      *      x Initialize_InvalidDirectoryArgument_OutputsError
@@ -95,6 +98,23 @@ namespace RiotClub.FireMoth.Console
 
             // Assert
             Assert.True(initializer.CommandLineOptions.RecursiveScan);
+        }
+
+        [Fact]
+        public void Initialize_QuotedDirectoryArgumentEndsWithBackslash_SetsDirectoryOptionWithoutTrailingDoubleQuote()
+        {
+            // Arrange
+            string quotedPath = @"""C:\ends with backslash\""";
+            string[] arguments = { "-d", quotedPath };
+            Initializer initializer = new Initializer(arguments, this.outputWriter);
+
+            // Act
+            initializer.Initialize();
+
+            // Assert
+            Assert.True(initializer.CommandLineOptions.ScanDirectory.Equals(
+                quotedPath.Substring(0, quotedPath.Length - 1),
+                StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]

--- a/FireMothConsole/FireMothConsole.xml
+++ b/FireMothConsole/FireMothConsole.xml
@@ -83,6 +83,13 @@
             <returns>An <see cref="T:RiotClub.FireMoth.Console.ExitState"/> indicating the result of the directory scan
             operation.</returns>
         </member>
+        <member name="M:RiotClub.FireMoth.Console.Initializer.RemoveTrailingDoubleQuote(System.String)">
+            <summary>
+            Removes a trailing double quote character from a string.
+            </summary>
+            <param name="s">A string.</param>
+            <returns>The string with one trailing double quote removed.</returns>
+        </member>
         <member name="M:RiotClub.FireMoth.Console.Initializer.ContainsInvalidPathCharacters(System.String)">
             <summary>
             Checks the provided string for invalid path characters.

--- a/FireMothConsole/Initializer.cs
+++ b/FireMothConsole/Initializer.cs
@@ -80,6 +80,10 @@ namespace RiotClub.FireMoth.Console
                 // Command line successfully parsed.
                 this.CommandLineOptions = ((Parsed<CommandLineOptions>)parseResult).Value;
 
+                // Check paths for trailing quotes.
+                this.CommandLineOptions.ScanDirectory =
+                    RemoveTrailingDoubleQuote(this.CommandLineOptions.ScanDirectory);
+
                 // Check for illegal characters in scan directory.
                 if (ContainsInvalidPathCharacters(this.CommandLineOptions.ScanDirectory))
                 {
@@ -154,6 +158,21 @@ namespace RiotClub.FireMoth.Console
             }
 
             return scanResult == ScanResult.ScanSuccess ? ExitState.Normal : ExitState.RuntimeError;
+        }
+
+        /// <summary>
+        /// Removes a trailing double quote character from a string.
+        /// </summary>
+        /// <param name="s">A string.</param>
+        /// <returns>The string with one trailing double quote removed.</returns>
+        private static string RemoveTrailingDoubleQuote(string s)
+        {
+            if (s.EndsWith('"'))
+            {
+                return s.Substring(0, s.Length - 1);
+            }
+
+            return s;
         }
 
         /// <summary>

--- a/FireMothConsole/Properties/launchSettings.json
+++ b/FireMothConsole/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "FireMothConsole": {
       "commandName": "Project",
-      "commandLineArgs": "-d c:\\"
+      "commandLineArgs": "-d \"D:/FireMoth Test Data/\""
     }
   }
 }


### PR DESCRIPTION
Path arguments are now checked for a trailing double quote character.
If found, the double quote is removed. If a path argument enclosed in
double quotes ended with a backslash, the last two characters would be
treated as the escape character \". This caused a trailing quote
character to be included on any such path argument, which resulted in
invalid path errors.